### PR TITLE
Fix video autoplay on iPhone Safari

### DIFF
--- a/_includes/hero.html
+++ b/_includes/hero.html
@@ -1,5 +1,5 @@
 <section class="video-banner-container l-gutter relative">
   <div class="embed embed-1by1 embed-hero">
-    <video class="embed-item-video" muted autoplay="autoplay" loop poster="https://grads.images.algonquindesign.ca/2018/videos/hero-video-poster.jpg" src="https://grads.images.algonquindesign.ca/2018/videos/hero-video.mp4" />
+    <video class="embed-item-video" muted autoplay loop playsinline poster="https://grads.images.algonquindesign.ca/2018/videos/hero-video-poster.jpg" src="https://grads.images.algonquindesign.ca/2018/videos/hero-video.mp4" />
   </div>
 </section>


### PR DESCRIPTION
- Video wasn't autoplaying on iPhone without the "playsinline" attribute.